### PR TITLE
Add sample FBX hedge pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
-#Demo
+# Demo
 
-Some plain text here!
+This repository provides a minimal skeleton for building a synthetic hedge on the Freightos Baltic Index (FBX) as described in the roadmap.
+
+## Structure
+
+```
+fbx_hedge/
+    config.py          # symbols and constants
+    run_daily_etl.py   # placeholder nightly ETL
+    utils.py           # helpers for loading and preparing data
+    fit_model.py       # LassoCV model training
+    size_positions.py  # compute contract quantities
+    monitor.py         # simple monitoring loop
+```
+
+The scripts are intentionally lightweight and focus on illustrating the workflow, not production readiness.

--- a/fbx_hedge/config.py
+++ b/fbx_hedge/config.py
@@ -1,0 +1,13 @@
+SYM = {
+    'FBX': 'freightos:global',
+    'BRN': 'ICE:BRN1!',  # Brent front
+    'BDI': 'SGX:BDI_F',  # dry-bulk FFA index future
+    'ES':  'CME:ES1!',   # S&P 500 E-mini
+}
+ROLL_DAYS = 3
+TRAIN_HORIZON_W = 104
+CONTRACT_MULTIPLIER = {
+    'BRN': 1000,
+    'ES': 50,
+    'BDI': 1,
+}

--- a/fbx_hedge/fit_model.py
+++ b/fbx_hedge/fit_model.py
@@ -1,0 +1,17 @@
+"""Train lasso model on returns."""
+import json
+import pandas as pd
+from sklearn.linear_model import LassoCV
+from sklearn.model_selection import TimeSeriesSplit
+from .utils import load_returns, make_design_matrix
+
+
+if __name__ == "__main__":
+    data = load_returns()
+    features, target = make_design_matrix(data)
+    split = TimeSeriesSplit(n_splits=5)
+    model = LassoCV(cv=split, alphas=[0.0001, 0.001, 0.01, 0.1, 1], max_iter=10000)
+    model.fit(features, target)
+    weights = pd.Series(model.coef_, index=features.columns)
+    with open('latest_weights.json', 'w') as fh:
+        json.dump(weights.to_dict(), fh, indent=2)

--- a/fbx_hedge/monitor.py
+++ b/fbx_hedge/monitor.py
@@ -1,0 +1,30 @@
+"""Simple tracking error monitor."""
+import json
+import time
+
+import pandas as pd
+
+
+LIVE_ERROR_THRESHOLD = 0.02
+
+
+def fetch_live_fbx_estimate():
+    return 0.0
+
+
+def fetch_live_futures_returns():
+    return pd.Series()
+
+
+if __name__ == "__main__":
+    with open('latest_weights.json') as fh:
+        weights = pd.Series(json.load(fh))
+
+    while True:
+        live_r_fbx = fetch_live_fbx_estimate()
+        live_r_futs = fetch_live_futures_returns()
+        synth_ret = (live_r_futs * weights).sum()
+        error = live_r_fbx - synth_ret
+        if abs(error) > LIVE_ERROR_THRESHOLD:
+            print('Hedge offside – investigate')
+        time.sleep(60)

--- a/fbx_hedge/run_daily_etl.py
+++ b/fbx_hedge/run_daily_etl.py
@@ -1,0 +1,25 @@
+"""Simplified ETL for price data."""
+import pandas as pd
+from pathlib import Path
+from .config import SYM
+
+RAW_DATA_DIR = Path('data/raw')
+RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def download(symbol_code):
+    """Placeholder for data download."""
+    # In production, call API or load file
+    return pd.DataFrame()
+
+
+def store_parquet(sym, df):
+    """Store DataFrame to Parquet."""
+    out = RAW_DATA_DIR / f"{sym}.parquet"
+    df.to_parquet(out)
+
+
+if __name__ == "__main__":
+    for sym, code in SYM.items():
+        raw = download(code)
+        store_parquet(sym, raw)

--- a/fbx_hedge/size_positions.py
+++ b/fbx_hedge/size_positions.py
@@ -1,0 +1,19 @@
+"""Calculate futures positions from model weights."""
+import json
+import pandas as pd
+from .config import CONTRACT_MULTIPLIER
+
+
+EXPOSURE_PER_FEU = 5000  # USD value of 1 FEU
+
+
+if __name__ == "__main__":
+    with open('latest_weights.json') as fh:
+        weights = pd.Series(json.load(fh))
+
+    contracts = {}
+    for sym, w in weights.items():
+        multiplier = CONTRACT_MULTIPLIER.get(sym, 1)
+        contracts[sym] = round(w * EXPOSURE_PER_FEU / multiplier, 2)
+
+    print("Contract sizes:", contracts)

--- a/fbx_hedge/utils.py
+++ b/fbx_hedge/utils.py
@@ -1,0 +1,22 @@
+"""Utility helpers."""
+import pandas as pd
+from pathlib import Path
+from .config import SYM
+
+RAW_DATA_DIR = Path('data/raw')
+
+
+def load_returns():
+    frames = {}
+    for sym in SYM:
+        f = RAW_DATA_DIR / f"{sym}.parquet"
+        if f.exists():
+            df = pd.read_parquet(f)
+            frames[sym] = df['close'].pct_change().rename(sym)
+    return pd.concat(frames.values(), axis=1)
+
+
+def make_design_matrix(data):
+    target = data['FBX']
+    features = data.drop(columns=['FBX'])
+    return features.fillna(0), target.fillna(0)


### PR DESCRIPTION
## Summary
- add FBX hedge skeleton with config, ETL, and model
- include sizing and monitoring scripts
- update README with repo structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401e9088348333888aa696b4f01f61